### PR TITLE
#137090989 Integrate HoundCI with badge attached to readme

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,3 @@
 jshint:
-  ignore_file: jshintignore
+  config_file: .jshintrc
+  fail_on_violations: true

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,24 @@
+{
+	  "node": true,
+	  "esnext": true,
+	  "bitwise": true,
+	  "camelcase": true,
+	  "curly": true,
+	  "eqeqeq": true,
+	  "immed": true,
+	  "indent": 2,
+	  "newcap": true,
+	  "noarg": true,
+	  "quotmark": "double",
+	  "regexp": true,
+	  "undef": false,
+	  "unused": false,
+	  "strict": false,
+	  "trailing": true,
+	  "smarttabs": true,
+	  "globals": {
+	    "require":false,
+	    "process":false
+	  },
+	  "jasmine": true,
+	}

--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,7 @@
 	  "indent": 2,
 	  "newcap": true,
 	  "noarg": true,
-	  "quotmark": "double",
+	  "quotmark": "single",
 	  "regexp": true,
 	  "undef": false,
 	  "unused": false,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 [![houndci](https://img.shields.io/badge/protected%20by-hound-orange.svg)](https://img.shields.io/badge/protected%20by-hound-orange.svg)
-
 [![Build Status](https://travis-ci.org/andela/temari-cfh.svg?branch=master)](https://travis-ci.org/andela/temari-cfh)
+[![Coverage Status](https://coveralls.io/repos/github/andela/temari-cfh/badge.svg?branch=develop)](https://coveralls.io/github/andela/temari-cfh?branch=develop)
 
 
 Cards for Humanity - [http://cfh.io](http://cfh.io)


### PR DESCRIPTION
#### The PR pull the request to test the HoundCI integration
#### This is to automatically validate the codebase with standard style guides
#### Sign up in the HoundCI site and link your repo, go to github and integrate HoundCI, config you #### jshint to work with hound, then you pull request for the test to run
#### Hound comments on style violations in GitHub pull requests, allowing you and your team to better review and maintain a clean codebase
#### The relevant story is for the HoundCI to work properly
####Questions: Is there any other CI that can do the same job as HoundCI